### PR TITLE
Draft implementation of aspect ratio sizing and positioning

### DIFF
--- a/theme.xml
+++ b/theme.xml
@@ -86,24 +86,15 @@ by:   	MrFull57
 		</image>
 		<helpsystem name="help-esquerdo">
 			<origin>0 0</origin>
-			<pos>0.025 0.925</pos>
 			<fontSize>0.026</fontSize>
-			<fontSizeDimmed>0.026</fontSizeDimmed>
 			<fontPath>${fontMedium}</fontPath>
 			<letterCase>capitalize</letterCase>
 			<iconColor>${CorLetrasGeral}</iconColor>
 			<textColor>${CorLetrasGeral}</textColor>
-			<originDimmed>0.5 0</originDimmed>
-			<posDimmed>0.5 0.94</posDimmed>
-			<textColorDimmed>3e3846</textColorDimmed>
-			<iconColorDimmed>3e3846</iconColorDimmed>
-			<opacityDimmed>1.0</opacityDimmed>
 			<scope>view</scope>
 		</helpsystem>
 		<image name="help-esquerdo-fundo">
 			<origin>0 1</origin>
-			<pos>0.012 0.97</pos>
-			<size>0.09 0.07</size>
 			<path>${spacerImage}</path>
 			<tile>true</tile>
 			<color>${CorMiniFundo}</color>
@@ -112,8 +103,6 @@ by:   	MrFull57
 		</image>
 		<image name="help-esquerdo-sombra">
 			<origin>0 1</origin>
-			<pos>0.015 0.976</pos>
-			<size>0.09 0.07</size>
 			<path>${spacerImage}</path>
 			<tile>true</tile>
 			<color>00000033</color>
@@ -122,23 +111,15 @@ by:   	MrFull57
 		</image>
 		<helpsystem name="help-direito">
 			<origin>1 0</origin>
-			<pos>0.975 0.925</pos>
 			<fontSize>0.026</fontSize>
-			<fontSizeDimmed>0.026</fontSizeDimmed>
 			<fontPath>${fontMedium}</fontPath>
 			<letterCase>capitalize</letterCase>
 			<iconColor>${CorLetrasGeral}</iconColor>
 			<textColor>${CorLetrasGeral}</textColor>
-			<originDimmed>0.5 0</originDimmed>
-			<posDimmed>0.5 0.94</posDimmed>
-			<textColorDimmed>3e3846</textColorDimmed>
-			<iconColorDimmed>3e3846</iconColorDimmed>
-			<opacityDimmed>1.0</opacityDimmed>
 			<scope>view</scope>
 		</helpsystem>
 		<image name="help-direito-fundo">
 			<origin>1 1</origin>
-			<pos>0.987 0.97</pos>
 			<path>${spacerImage}</path>
 			<tile>true</tile>
 			<color>${CorMiniFundo}</color>
@@ -147,7 +128,6 @@ by:   	MrFull57
 		</image>
 		<image name="help-direito-sombra">
 			<origin>1 1</origin>
-			<pos>0.990 0.976</pos>
 			<path>${spacerImage}</path>
 			<tile>true</tile>
 			<color>00000033</color>
@@ -175,7 +155,6 @@ by:   	MrFull57
 			<fontPath>${fontMedium}</fontPath>
 			<height>0.042</height>
 			<color>${CorLetrasTitulos}</color>
-			<pos>0.98 0.0615</pos>
 			<customIcon icon="icon_bluetooth">./_inc/images/icon-bt.svg</customIcon>
 			<customIcon icon="icon_wifi">./_inc/images/icon-wifi.svg</customIcon>
 			<customIcon icon="icon_cellular">./_inc/images/icon-cellular.svg</customIcon>
@@ -184,14 +163,12 @@ by:   	MrFull57
 			<fontPath>${fontMedium}</fontPath>
 			<fontSize>0.037</fontSize>
 			<color>${CorLetrasTitulos}</color>
-			<pos>0.785 0.064</pos>
 			<horizontalAlignment>center</horizontalAlignment>
 		</clock>
 		<clock name="data-de-hoje">
 			<fontPath>${fontMedium}</fontPath>
 			<fontSize>0.037</fontSize>
 			<color>${CorLetrasTitulos}</color>
-			<pos>0.873 0.064</pos>
 			<format>%d/%m</format>
 			<horizontalAlignment>center</horizontalAlignment>
 		</clock>
@@ -344,19 +321,13 @@ by:   	MrFull57
 		<helpsystem name="help-direito">
 			<entries>a</entries>
 		</helpsystem>
-		<image name="help-direito-fundo">
-			<size>0.115 0.07</size>
-		</image>
-		<image name="help-direito-sombra">
-			<size>0.115 0.07</size>
-		</image>
 	</view>
 	<fontSize name="medium">
-			<variables>
-				<systemGameCountFontSize>0.030</systemGameCountFontSize>
-				<systemMetadataFontSize>0.026</systemMetadataFontSize>
-			</variables>
-		</fontSize>
+		<variables>
+			<systemGameCountFontSize>0.030</systemGameCountFontSize>
+			<systemMetadataFontSize>0.026</systemMetadataFontSize>
+		</variables>
+	</fontSize>
    
 	<!--///	Gamelist View: Carousel	///-->
 	<variant name="gamelist-carousel">
@@ -593,12 +564,6 @@ by:   	MrFull57
 			<helpsystem name="help-direito">
 				<entries>start,back,x,y,a</entries>
 			</helpsystem>
-			<image name="help-direito-fundo">
-				<size>0.455 0.07</size>
-			</image>
-			<image name="help-direito-sombra">
-				<size>0.455 0.07</size>
-			</image>
 		</view>
 		<fontSize name="medium">
 			<variables>
@@ -692,50 +657,246 @@ by:   	MrFull57
 
 	<!--///	Aspect Ratios ///-->
 	<aspectRatio name="16:9">
+		<!-- Based on 1920x1080 -->
 		<view name="system,gamelist">
+			<image name="reloginho,reloginho-sombra">
+				<size>0.26510417 0</size><!-- 509 0 -->
+			</image>
 			<image name="reloginho">
-				<pos>1 0.04</pos>
-				<size>0.265 0</size>
+				<pos>1 0.03981481</pos><!-- 1920 43 -->
 			</image>
 			<image name="reloginho-sombra">
-				<pos>1.003 0.046</pos>
-				<size>0.265 0</size>
+				<pos>1.00260417 0.04537037</pos><!-- 1925 49 -->
+			</image>
+			<systemstatus name="system-status">
+				<pos>0.98020833 0.06111111</pos><!-- 1882 66 -->
+			</systemstatus>
+			<clock name="clock">
+				<pos>0.78489583 0.06388889</pos><!-- 1507 69 -->
+			</clock>
+			<clock name="data-de-hoje">
+				<pos>0.87291667 0.06388889</pos><!-- 1676 69 -->
+			</clock>
+			<helpsystem name="help-esquerdo,help-direito">
+				<entrySpacing>0.00833333</entrySpacing><!-- 16 -->
+				<iconTextSpacing>0.00416667</iconTextSpacing><!-- 8 -->
+			</helpsystem>
+			<helpsystem name="help-esquerdo">
+				<pos>0.025 0.925</pos><!-- 48 999 -->
+			</helpsystem>
+			<image name="help-esquerdo-fundo">
+				<pos>0.01302083 0.97037037</pos><!-- 25 1048 -->
+			</image>
+			<image name="help-esquerdo-sombra">
+				<pos>0.015625 0.97777778</pos><!-- 30 1056 -->
+			</image>
+			<helpsystem name="help-direito">
+				<pos>0.975 0.925</pos><!-- 1872 999 -->
+			</helpsystem>
+			<image name="help-direito-fundo">
+				<pos>0.987 0.97037037</pos><!-- 1895 1048 -->
+			</image>
+			<image name="help-direito-sombra">
+				<pos>0.98958333 0.97777778</pos><!-- 1900 1056 -->
+			</image>
+		</view>
+		<view name="system">
+			<image name="help-esquerdo-fundo,help-esquerdo-sombra">
+				<size>0.08125 0.06944444</size><!-- 156 75 -->
+			</image>
+			<image name="help-direito-fundo,help-direito-sombra">
+				<size>0.08645833 0.06944444</size><!-- 166 75 -->
+			</image>
+		</view>
+		<view name="gamelist">
+			<image name="help-esquerdo-fundo,help-esquerdo-sombra">
+				<size>0.08125 0.06944444</size><!-- 156 75 -->
+			</image>
+			<image name="help-direito-fundo,help-direito-sombra">
+				<size>0.4375 0.06944444</size><!-- 840 75 -->
 			</image>
 		</view>
     </aspectRatio>
 	<aspectRatio name="16:10">
+		<!-- Based on 1728x1080 -->
 		<view name="system,gamelist">
+			<image name="reloginho,reloginho-sombra">
+				<size>0.29456019 0</size><!-- 509 0 -->
+			</image>
 			<image name="reloginho">
-				<pos>1 0.04</pos>
-				<size>0.265 0</size>
+				<pos>1 0.03981481</pos><!-- 1920 43 -->
 			</image>
 			<image name="reloginho-sombra">
-				<pos>1.003 0.046</pos>
-				<size>0.265 0</size>
+				<pos>1.00289352 0.04537037</pos><!-- 1733 49 -->
+			</image>
+			<systemstatus name="system-status">
+				<pos>0.97800926 0.06111111</pos><!-- 1690 66 -->
+			</systemstatus>
+			<clock name="clock">
+				<pos>0.76099537 0.06388889</pos><!-- 1315 69 -->
+			</clock>
+			<clock name="data-de-hoje">
+				<pos>0.8587963 0.06388889</pos><!-- 1484 69 -->
+			</clock>
+			<helpsystem name="help-esquerdo,help-direito">
+				<entrySpacing>0.00925926</entrySpacing><!-- 16 -->
+				<iconTextSpacing>0.00462963</iconTextSpacing><!-- 8 -->
+			</helpsystem>
+			<helpsystem name="help-esquerdo">
+				<pos>0.02777778 0.925</pos><!-- 48 999 -->
+			</helpsystem>
+			<image name="help-esquerdo-fundo">
+				<pos>0.01446759 0.97037037</pos><!-- 25 1048 -->
+			</image>
+			<image name="help-esquerdo-sombra">
+				<pos>0.01736111 0.97777778</pos><!-- 30 1056 -->
+			</image>
+			<helpsystem name="help-direito">
+				<pos>0.97222222 0.925</pos><!-- 1680 999 -->
+			</helpsystem>
+			<image name="help-direito-fundo">
+				<pos>0.98553241 0.97037037</pos><!-- 1703 1048 -->
+			</image>
+			<image name="help-direito-sombra">
+				<pos>0.98842593 0.97777778</pos><!-- 1708 1056 -->
+			</image>
+		</view>
+		<view name="system">
+			<image name="help-esquerdo-fundo,help-esquerdo-sombra">
+				<size>0.09027778 0.06944444</size><!-- 156 75 -->
+			</image>
+			<image name="help-direito-fundo,help-direito-sombra">
+				<size>0.09606481 0.06944444</size><!-- 166 75 -->
+			</image>
+		</view>
+		<view name="gamelist">
+			<image name="help-esquerdo-fundo,help-esquerdo-sombra">
+				<size>0.09027778 0.06944444</size><!-- 156 75 -->
+			</image>
+			<image name="help-direito-fundo,help-direito-sombra">
+				<size>0.48611111 0.06944444</size><!-- 840 75 -->
 			</image>
 		</view>
     </aspectRatio>
 	<aspectRatio name="4:3">
+		<!-- Based on 1440x1080 -->
 		<view name="system,gamelist">
+			<image name="reloginho,reloginho-sombra">
+				<size>0.35347222 0</size><!-- 509 0 -->
+			</image>
 			<image name="reloginho">
-				<pos>1 0.04</pos>
-				<size>0.19866 0</size>
+				<pos>1 0.03981481</pos><!-- 1920 43 -->
 			</image>
 			<image name="reloginho-sombra">
-				<pos>1.003 0.046</pos>
-				<size>0.19866 0</size>
+				<pos>1.00347222 0.04537037</pos><!-- 1445 49 -->
+			</image>
+			<systemstatus name="system-status">
+				<pos>0.97361111 0.06111111</pos><!-- 1402 66 -->
+			</systemstatus>
+			<clock name="clock">
+				<pos>0.71319444 0.06388889</pos><!-- 1027 69 -->
+			</clock>
+			<clock name="data-de-hoje">
+				<pos>0.83055556 0.06388889</pos><!-- 1196 69 -->
+			</clock>
+			<helpsystem name="help-esquerdo,help-direito">
+				<entrySpacing>0.01111111</entrySpacing><!-- 16 -->
+				<iconTextSpacing>0.00555556</iconTextSpacing><!-- 8 -->
+			</helpsystem>
+			<helpsystem name="help-esquerdo">
+				<pos>0.03333333 0.925</pos><!-- 48 999 -->
+			</helpsystem>
+			<image name="help-esquerdo-fundo">
+				<pos>0.01736111 0.97037037</pos><!-- 25 1048 -->
+			</image>
+			<image name="help-esquerdo-sombra">
+				<pos>0.02083333 0.97777778</pos><!-- 30 1056 -->
+			</image>
+			<helpsystem name="help-direito">
+				<pos>0.96666667 0.925</pos><!-- 1392 999 -->
+			</helpsystem>
+			<image name="help-direito-fundo">
+				<pos>0.98263889 0.97037037</pos><!-- 1415 1048 -->
+			</image>
+			<image name="help-direito-sombra">
+				<pos>0.98611111 0.97777778</pos><!-- 1420 1056 -->
+			</image>
+		</view>
+		<view name="system">
+			<image name="help-esquerdo-fundo,help-esquerdo-sombra">
+				<size>0.10833333 0.06944444</size><!-- 156 75 -->
+			</image>
+			<image name="help-direito-fundo,help-direito-sombra">
+				<size>0.11527778 0.06944444</size><!-- 166 75 -->
+			</image>
+		</view>
+		<view name="gamelist">
+			<image name="help-esquerdo-fundo,help-esquerdo-sombra">
+				<size>0.10833333 0.06944444</size><!-- 156 75 -->
+			</image>
+			<image name="help-direito-fundo,help-direito-sombra">
+				<size>0.58333333 0.06944444</size><!-- 840 75 -->
 			</image>
 		</view>
     </aspectRatio>
 	<aspectRatio name="21:9">
+		<!-- Based on 2520x1080 -->
 		<view name="system,gamelist">
+			<image name="reloginho,reloginho-sombra">
+				<size>0.20198413 0</size><!-- 509 0 -->
+			</image>
 			<image name="reloginho">
-				<pos>1 0.04</pos>
-				<size>0.34774 0</size>
+				<pos>1 0.03981481</pos><!-- 1920 43 -->
 			</image>
 			<image name="reloginho-sombra">
-				<pos>1.003 0.046</pos>
-				<size>0.34774 0</size>
+				<pos>1.00198413 0.04537037</pos><!-- 2525 49 -->
+			</image>
+			<systemstatus name="system-status">
+				<pos>0.98492063 0.06111111</pos><!-- 2482 66 -->
+			</systemstatus>
+			<clock name="clock">
+				<pos>0.83611111 0.06388889</pos><!-- 2107 69 -->
+			</clock>
+			<clock name="data-de-hoje">
+				<pos>0.9031746 0.06388889</pos><!-- 2276 69 -->
+			</clock>
+			<helpsystem name="help-esquerdo,help-direito">
+				<entrySpacing>0.00627451</entrySpacing><!-- 16 -->
+				<iconTextSpacing>0.0031746</iconTextSpacing><!-- 8 -->
+			</helpsystem>
+			<helpsystem name="help-esquerdo">
+				<pos>0.01904762 0.925</pos><!-- 48 999 -->
+			</helpsystem>
+			<image name="help-esquerdo-fundo">
+				<pos>0.00992063 0.97037037</pos><!-- 25 1048 -->
+			</image>
+			<image name="help-esquerdo-sombra">
+				<pos>0.01190476 0.97777778</pos><!-- 30 1056 -->
+			</image>
+			<helpsystem name="help-direito">
+				<pos>0.98095238 0.925</pos><!-- 2472 999 -->
+			</helpsystem>
+			<image name="help-direito-fundo">
+				<pos>0.99007937 0.97037037</pos><!-- 2495 1048 -->
+			</image>
+			<image name="help-direito-sombra">
+				<pos>0.99206349 0.97777778</pos><!-- 2500 1056 -->
+			</image>
+		</view>
+		<view name="system">
+			<image name="help-esquerdo-fundo,help-esquerdo-sombra">
+				<size>0.06190476 0.06944444</size><!-- 156 75 -->
+			</image>
+			<image name="help-direito-fundo,help-direito-sombra">
+				<size>0.06587302 0.06944444</size><!-- 166 75 -->
+			</image>
+		</view>
+		<view name="gamelist">
+			<image name="help-esquerdo-fundo,help-esquerdo-sombra">
+				<size>0.06190476 0.06944444</size><!-- 156 75 -->
+			</image>
+			<image name="help-direito-fundo,help-direito-sombra">
+				<size>0.33333333 0.06944444</size><!-- 840 75 -->
 			</image>
 		</view>
     </aspectRatio>


### PR DESCRIPTION
I took an initial pass at showing how I would recommend approaching the sizing and positioning of elements for different aspect ratios

Ultimately it based on quick math which I find makes it easier to get things sizing consistently and placed consistently in all aspect ratios

Video walkthrough here:
https://github.com/user-attachments/assets/bdbd0343-52ad-4b52-a176-cd8662647b6a

The basic idea is that I set a baseline height for all aspect ratios (in this example that is `1080`) so that all height and y position values can be calculated once and used across all aspect ratios

Then I calculate the width and x position values based on the width of the screen for a given aspect ratio.

For example 16:9 would be 1920x1080 so that would mean if I have something that I want to be `509` width then it would be `0.26510417` (or 509/1920) in percentage

That same 509 width for 16:10 would be `0.29456019` in percentage (i.e. 508/1728) because the 16:10 screen width at a 1080 height would be 1728

Hopefully that makes sense but I am glad to talk through it more here or on discord so just let me know.

Also, if this method doesn't work for you then all good!  There are other ways to approach this too.  I just find the above method works the easiest for me when trying to get consistent widths across aspect ratios. 

Cheers, Ant