### PR TITLE
Add "Clean" color schemes to toggle game art background (Resolves #8)

### DIFF
--- a/capabilities.xml
+++ b/capabilities.xml
@@ -181,6 +181,30 @@
         <label language="zh_TW">明亮</label>
     </colorScheme>
 
+    <colorScheme name="light-clean">
+        <label language="en_US">Light (Clean)</label>
+        <label language="en_GB">Light (Clean)</label>
+        <label language="bs_BA">Naravno (Čisto)</label>
+        <label language="ca_ES">Clar (Net)</label>
+        <label language="de_DE">Hell (Sauber)</label>
+        <label language="es_ES">Claro (Limpio)</label>
+        <label language="fr_FR">Clair (Propre)</label>
+        <label language="hr_HR">Naravno (Čisto)</label>
+        <label language="it_IT">Chiaro (Pulito)</label>
+        <label language="nl_NL">Licht (Schoon)</label>
+        <label language="pl_PL">Jasna (Czysta)</label>
+        <label language="pt_BR">Claro (Limpo)</label>
+        <label language="pt_PT">Claro (Limpo)</label>
+        <label language="ro_RO">Luminoasă (Curată)</label>
+        <label language="ru_RU">Светлая (Чистая)</label>
+        <label language="sr_RS">Наравно (Чисто)</label>
+        <label language="sv_SE">Ljust (Rent)</label>
+        <label language="ja_JP">ライト（クリーン）</label>
+        <label language="ko_KR">라이트(클린)</label>
+        <label language="zh_CN">明亮（干净）</label>
+        <label language="zh_TW">明亮（乾淨）</label>
+    </colorScheme>
+
     <colorScheme name="dark">
         <label language="en_US">Dark</label>
 		<label language="en_GB">Dark</label>
@@ -203,6 +227,30 @@
         <label language="ko_KR">다크</label>
         <label language="zh_CN">暗黑</label>
         <label language="zh_TW">暗黑</label>
+    </colorScheme>
+
+    <colorScheme name="dark-clean">
+        <label language="en_US">Dark (Clean)</label>
+        <label language="en_GB">Dark (Clean)</label>
+        <label language="bs_BA">Tamno (Čisto)</label>
+        <label language="ca_ES">Fosc (Net)</label>
+        <label language="de_DE">Dunkel (Sauber)</label>
+        <label language="es_ES">Oscuro (Limpio)</label>
+        <label language="fr_FR">Foncé (Propre)</label>
+        <label language="hr_HR">Tamno (Čisto)</label>
+        <label language="it_IT">Scuro (Pulito)</label>
+        <label language="nl_NL">Donker (Schoon)</label>
+        <label language="pl_PL">Ciemna (Czysta)</label>
+        <label language="pt_BR">Escuro (Limpo)</label>
+        <label language="pt_PT">Escuro (Limpo)</label>
+        <label language="ro_RO">Întunecată (Curată)</label>
+        <label language="ru_RU">Тёмная (Чистая)</label>
+        <label language="sr_RS">Тамно (Чисто)</label>
+        <label language="sv_SE">Mörkt (Rent)</label>
+        <label language="ja_JP">ダーク（クリーン）</label>
+        <label language="ko_KR">다크(클린)</label>
+        <label language="zh_CN">暗黑（干净）</label>
+        <label language="zh_TW">暗黑（乾淨）</label>
     </colorScheme>
 
     <colorScheme name="blue">
@@ -229,6 +277,30 @@
         <label language="zh_TW">藍色的</label>
     </colorScheme>
 	
+    <colorScheme name="blue-clean">
+        <label language="en_US">Blue (Clean)</label>
+        <label language="en_GB">Blue (Clean)</label>
+        <label language="bs_BA">Plava (Čisto)</label>
+        <label language="ca_ES">Blau (Net)</label>
+        <label language="de_DE">Blau (Sauber)</label>
+        <label language="es_ES">Azul (Limpio)</label>
+        <label language="fr_FR">Bleu (Propre)</label>
+        <label language="hr_HR">Plava (Čisto)</label>
+        <label language="it_IT">Blu (Pulito)</label>
+        <label language="nl_NL">Blauw (Schoon)</label>
+        <label language="pl_PL">Niebieski (Czysty)</label>
+        <label language="pt_BR">Azul (Limpo)</label>
+        <label language="pt_PT">Azul (Limpo)</label>
+        <label language="ro_RO">Albastru (Curat)</label>
+        <label language="ru_RU">Синий (Чистый)</label>
+        <label language="sr_RS">Плава (Чисто)</label>
+        <label language="sv_SE">Blå (Rent)</label>
+        <label language="ja_JP">青い（クリーン）</label>
+        <label language="ko_KR">파란색(클린)</label>
+        <label language="zh_CN">蓝色的（干净）</label>
+        <label language="zh_TW">藍色的（乾淨）</label>
+    </colorScheme>
+	
     <colorScheme name="green">
         <label language="en_US">Green</label>
 		<label language="en_GB">Green</label>
@@ -253,6 +325,30 @@
         <label language="zh_TW">綠色</label>
     </colorScheme>
 
+    <colorScheme name="green-clean">
+        <label language="en_US">Green (Clean)</label>
+        <label language="en_GB">Green (Clean)</label>
+        <label language="bs_BA">Zelena (Čisto)</label>
+        <label language="ca_ES">Verd (Net)</label>
+        <label language="de_DE">Grün (Sauber)</label>
+        <label language="es_ES">Verde (Limpio)</label>
+        <label language="fr_FR">Vert (Propre)</label>
+        <label language="hr_HR">Zelena (Čisto)</label>
+        <label language="it_IT">Verde (Pulito)</label>
+        <label language="nl_NL">Groen (Schoon)</label>
+        <label language="pl_PL">Zielony (Czysty)</label>
+        <label language="pt_BR">Verde (Limpo)</label>
+        <label language="pt_PT">Verde (Limpo)</label>
+        <label language="ro_RO">Verde (Curat)</label>
+        <label language="ru_RU">Зелёный (Чистый)</label>
+        <label language="sr_RS">Зелена (Чисто)</label>
+        <label language="sv_SE">Grön (Rent)</label>
+        <label language="ja_JP">グリーン（クリーン）</label>
+        <label language="ko_KR">그린(클린)</label>
+        <label language="zh_CN">绿色（干净）</label>
+        <label language="zh_TW">綠色（乾淨）</label>
+    </colorScheme>
+
     <colorScheme name="teal">
         <label language="en_US">Teal</label>
 		<label language="en_GB">Teal</label>
@@ -275,6 +371,30 @@
         <label language="ko_KR">틸</label>
         <label language="zh_CN">蓝绿色</label>
         <label language="zh_TW">藍綠色</label>
+    </colorScheme>
+
+    <colorScheme name="teal-clean">
+        <label language="en_US">Teal (Clean)</label>
+        <label language="en_GB">Teal (Clean)</label>
+        <label language="bs_BA">Tirkizna (Čisto)</label>
+        <label language="ca_ES">Turquesa (Net)</label>
+        <label language="de_DE">Türkis (Sauber)</label>
+        <label language="es_ES">Verde Azulado (Limpio)</label>
+        <label language="fr_FR">Sarcelle (Propre)</label>
+        <label language="hr_HR">Tirkizna (Čisto)</label>
+        <label language="it_IT">Verde Petrolio (Pulito)</label>
+        <label language="nl_NL">Turkoois (Schoon)</label>
+        <label language="pl_PL">Morski (Czysty)</label>
+        <label language="pt_BR">Azul Petróleo (Limpo)</label>
+        <label language="pt_PT">Azul Petróleo (Limpo)</label>
+        <label language="ro_RO">Turcoaz (Curat)</label>
+        <label language="ru_RU">Бирюзовый (Чистый)</label>
+        <label language="sr_RS">Тиркизна (Чисто)</label>
+        <label language="sv_SE">Teal (Rent)</label>
+        <label language="ja_JP">ティール（クリーン）</label>
+        <label language="ko_KR">틸(클린)</label>
+        <label language="zh_CN">蓝绿色（干净）</label>
+        <label language="zh_TW">藍綠色（乾淨）</label>
     </colorScheme>
 
 </themeCapabilities>

--- a/theme.xml
+++ b/theme.xml
@@ -27,6 +27,7 @@ by:   	MrFull57
 			<CorLetrasTitulos>403a46</CorLetrasTitulos>
 			<FundoOpacidade>0.24</FundoOpacidade>
 			<FundoSaturacao>1</FundoSaturacao>
+			<MostrarArteFundo>true</MostrarArteFundo>
 			<CorMiniFundo>ffffff</CorMiniFundo>
 			<CorHelpFundo>ffffffcc</CorHelpFundo>
 			<CorHelpFundo2>d1cddacc</CorHelpFundo2>
@@ -35,7 +36,26 @@ by:   	MrFull57
 			<ItemForaOpacidade>0.7</ItemForaOpacidade>
 			<ItemForaTonalidade>0.97</ItemForaTonalidade>
 		</variables>
-    </colorScheme>
+	</colorScheme>
+	<colorScheme name="light-clean">
+		<variables>
+			<CorFundoTopo>f4f4f4</CorFundoTopo>
+			<CorFundoRodape>ececec</CorFundoRodape>
+			<CorFundoBolinhas>ffffff</CorFundoBolinhas>
+			<CorLetrasGeral>403a46</CorLetrasGeral>
+			<CorLetrasTitulos>403a46</CorLetrasTitulos>
+			<FundoOpacidade>0.24</FundoOpacidade>
+			<FundoSaturacao>1</FundoSaturacao>
+			<MostrarArteFundo>false</MostrarArteFundo>
+			<CorMiniFundo>ffffff</CorMiniFundo>
+			<CorHelpFundo>ffffffcc</CorHelpFundo>
+			<CorHelpFundo2>d1cddacc</CorHelpFundo2>
+			<CorDeFato>light</CorDeFato>
+			<ImagemSeletor>./_inc/images/grid-seletor-light.png</ImagemSeletor>
+			<ItemForaOpacidade>0.7</ItemForaOpacidade>
+			<ItemForaTonalidade>0.97</ItemForaTonalidade>
+		</variables>
+	</colorScheme>
 	<colorScheme name="dark">
 		<variables>
 			<CorFundoTopo>262626</CorFundoTopo>
@@ -45,6 +65,7 @@ by:   	MrFull57
 			<CorLetrasTitulos>e0e0e0</CorLetrasTitulos>
 			<FundoOpacidade>0.12</FundoOpacidade>
 			<FundoSaturacao>1</FundoSaturacao>
+			<MostrarArteFundo>true</MostrarArteFundo>
 			<CorMiniFundo>e0e0e0</CorMiniFundo>
 			<CorHelpFundo>ffffff44</CorHelpFundo>
 			<CorHelpFundo2>d1cdda44</CorHelpFundo2>
@@ -53,7 +74,26 @@ by:   	MrFull57
 			<ItemForaOpacidade>0.97</ItemForaOpacidade>
 			<ItemForaTonalidade>0.7</ItemForaTonalidade>
 		</variables>
-    </colorScheme>
+	</colorScheme>
+	<colorScheme name="dark-clean">
+		<variables>
+			<CorFundoTopo>262626</CorFundoTopo>
+			<CorFundoRodape>161616</CorFundoRodape>
+			<CorFundoBolinhas>3c3c3c</CorFundoBolinhas>
+			<CorLetrasGeral>403a46</CorLetrasGeral>
+			<CorLetrasTitulos>e0e0e0</CorLetrasTitulos>
+			<FundoOpacidade>0.12</FundoOpacidade>
+			<FundoSaturacao>1</FundoSaturacao>
+			<MostrarArteFundo>false</MostrarArteFundo>
+			<CorMiniFundo>e0e0e0</CorMiniFundo>
+			<CorHelpFundo>ffffff44</CorHelpFundo>
+			<CorHelpFundo2>d1cdda44</CorHelpFundo2>
+			<CorDeFato>dark</CorDeFato>
+			<ImagemSeletor>./_inc/images/grid-seletor-dark.png</ImagemSeletor>
+			<ItemForaOpacidade>0.97</ItemForaOpacidade>
+			<ItemForaTonalidade>0.7</ItemForaTonalidade>
+		</variables>
+	</colorScheme>
 	<colorScheme name="blue">
 		<variables>
 			<CorFundoTopo>1c2c68</CorFundoTopo>
@@ -63,6 +103,7 @@ by:   	MrFull57
 			<CorLetrasTitulos>f0eff1</CorLetrasTitulos>
 			<FundoOpacidade>0.15</FundoOpacidade>
 			<FundoSaturacao>0.5</FundoSaturacao>
+			<MostrarArteFundo>true</MostrarArteFundo>
 			<CorMiniFundo>f0eff1</CorMiniFundo>
 			<CorHelpFundo>ffffff44</CorHelpFundo>
 			<CorHelpFundo2>d1cdda44</CorHelpFundo2>
@@ -71,7 +112,26 @@ by:   	MrFull57
 			<ItemForaOpacidade>0.97</ItemForaOpacidade>
 			<ItemForaTonalidade>0.7</ItemForaTonalidade>
 		</variables>
-    </colorScheme>
+	</colorScheme>
+	<colorScheme name="blue-clean">
+		<variables>
+			<CorFundoTopo>1c2c68</CorFundoTopo>
+			<CorFundoRodape>121258</CorFundoRodape>
+			<CorFundoBolinhas>233688</CorFundoBolinhas>
+			<CorLetrasGeral>5c5a91</CorLetrasGeral>
+			<CorLetrasTitulos>f0eff1</CorLetrasTitulos>
+			<FundoOpacidade>0.15</FundoOpacidade>
+			<FundoSaturacao>0.5</FundoSaturacao>
+			<MostrarArteFundo>false</MostrarArteFundo>
+			<CorMiniFundo>f0eff1</CorMiniFundo>
+			<CorHelpFundo>ffffff44</CorHelpFundo>
+			<CorHelpFundo2>d1cdda44</CorHelpFundo2>
+			<CorDeFato>blue</CorDeFato>
+			<ImagemSeletor>./_inc/images/grid-seletor-dark.png</ImagemSeletor>
+			<ItemForaOpacidade>0.97</ItemForaOpacidade>
+			<ItemForaTonalidade>0.7</ItemForaTonalidade>
+		</variables>
+	</colorScheme>
 	<colorScheme name="green">
 		<variables>
 			<CorFundoTopo>1b5e20</CorFundoTopo>
@@ -81,6 +141,7 @@ by:   	MrFull57
 			<CorLetrasTitulos>e8f5e9</CorLetrasTitulos>
 			<FundoOpacidade>0.15</FundoOpacidade>
 			<FundoSaturacao>0.6</FundoSaturacao>
+			<MostrarArteFundo>true</MostrarArteFundo>
 			<CorMiniFundo>e8f5e9</CorMiniFundo>
 			<CorHelpFundo>ffffff44</CorHelpFundo>
 			<CorHelpFundo2>d1cdda44</CorHelpFundo2>
@@ -89,7 +150,26 @@ by:   	MrFull57
 			<ItemForaOpacidade>0.97</ItemForaOpacidade>
 			<ItemForaTonalidade>0.7</ItemForaTonalidade>
 		</variables>
-    </colorScheme>
+	</colorScheme>
+	<colorScheme name="green-clean">
+		<variables>
+			<CorFundoTopo>1b5e20</CorFundoTopo>
+			<CorFundoRodape>0d3b13</CorFundoRodape>
+			<CorFundoBolinhas>2e7d32</CorFundoBolinhas>
+			<CorLetrasGeral>6d8f6d</CorLetrasGeral>
+			<CorLetrasTitulos>e8f5e9</CorLetrasTitulos>
+			<FundoOpacidade>0.15</FundoOpacidade>
+			<FundoSaturacao>0.6</FundoSaturacao>
+			<MostrarArteFundo>false</MostrarArteFundo>
+			<CorMiniFundo>e8f5e9</CorMiniFundo>
+			<CorHelpFundo>ffffff44</CorHelpFundo>
+			<CorHelpFundo2>d1cdda44</CorHelpFundo2>
+			<CorDeFato>green</CorDeFato>
+			<ImagemSeletor>./_inc/images/grid-seletor-dark.png</ImagemSeletor>
+			<ItemForaOpacidade>0.97</ItemForaOpacidade>
+			<ItemForaTonalidade>0.7</ItemForaTonalidade>
+		</variables>
+	</colorScheme>
 	<colorScheme name="teal">
 		<variables>
 			<CorFundoTopo>00695c</CorFundoTopo>
@@ -99,6 +179,7 @@ by:   	MrFull57
 			<CorLetrasTitulos>e0f2f1</CorLetrasTitulos>
 			<FundoOpacidade>0.15</FundoOpacidade>
 			<FundoSaturacao>0.55</FundoSaturacao>
+			<MostrarArteFundo>true</MostrarArteFundo>
 			<CorMiniFundo>e0f2f1</CorMiniFundo>
 			<CorHelpFundo>ffffff44</CorHelpFundo>
 			<CorHelpFundo2>d1cdda44</CorHelpFundo2>
@@ -107,7 +188,26 @@ by:   	MrFull57
 			<ItemForaOpacidade>0.97</ItemForaOpacidade>
 			<ItemForaTonalidade>0.7</ItemForaTonalidade>
 		</variables>
-    </colorScheme>
+	</colorScheme>
+	<colorScheme name="teal-clean">
+		<variables>
+			<CorFundoTopo>00695c</CorFundoTopo>
+			<CorFundoRodape>004d40</CorFundoRodape>
+			<CorFundoBolinhas>00796b</CorFundoBolinhas>
+			<CorLetrasGeral>5e8f88</CorLetrasGeral>
+			<CorLetrasTitulos>e0f2f1</CorLetrasTitulos>
+			<FundoOpacidade>0.15</FundoOpacidade>
+			<FundoSaturacao>0.55</FundoSaturacao>
+			<MostrarArteFundo>false</MostrarArteFundo>
+			<CorMiniFundo>e0f2f1</CorMiniFundo>
+			<CorHelpFundo>ffffff44</CorHelpFundo>
+			<CorHelpFundo2>d1cdda44</CorHelpFundo2>
+			<CorDeFato>teal</CorDeFato>
+			<ImagemSeletor>./_inc/images/grid-seletor-dark.png</ImagemSeletor>
+			<ItemForaOpacidade>0.97</ItemForaOpacidade>
+			<ItemForaTonalidade>0.7</ItemForaTonalidade>
+		</variables>
+	</colorScheme>
 
 	<!--///	Todas as Views ///-->
 	<view name="system,gamelist">
@@ -360,6 +460,7 @@ by:   	MrFull57
 			<scrollFadeIn>true</scrollFadeIn>
 			<opacity>${FundoOpacidade}</opacity>
 			<saturation>${FundoSaturacao}</saturation>
+			<visible>${MostrarArteFundo}</visible>
 		</image>
 
 		<image name="system-icon">


### PR DESCRIPTION
I'm the author of Issue #8. I've implemented a solution to allow toggling the game art background in the Gamelist View.

I initially considered creating a specific "Variant" for this (e.g., "Clean Background"). However, after reviewing the [ES-DE theming documentation](https://gitlab.com/es-de/emulationstation-de/-/blob/master/THEMES.md), I realized that since variants are mutually exclusive, I would have to create combinatorial variants (like "Grid - Clean", "Carousel - Clean") and duplicate layout logic across every single aspect-ratio file to prevent the UI from breaking.

**The Solution:**
Instead, I utilized the **Color Schemes**. I created "Clean" versions of the existing schemes (Light-Clean, Dark-Clean, etc.). These schemes simply set an internal visibility variable (`MostrarArteFundo`) to `false`.

This approach allows the user to keep their preferred layout (Grid or Carousel) intact while controlling the background via the Color selector.

**Regarding Custom Images:**
I decided to drop the "Custom Image" idea mentioned in the issue to focus solely on the main goal: showing or hiding the game art background. Supporting custom images would likely still require manual file replacement by the user, which felt outside the scope of a clean UI fix.

I am aware that this approach requires duplicating the color definitions in `theme.xml`. If you find this adds too much clutter or isn't the direction you want for the theme, please feel free to close this PR (and Issue #8, as I now better understand the current limitations regarding additive options).

Thanks for your work!